### PR TITLE
Updates to CFN to privatize S3 bucket and expose assets via cloudfront only.

### DIFF
--- a/infrastructure/cfn-deployer/skill-stack.yaml
+++ b/infrastructure/cfn-deployer/skill-stack.yaml
@@ -42,8 +42,11 @@ Resources:
   S3WebAppBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Delete
-    Properties:
-      AccessControl: PublicRead
+  S3OriginAccessID:
+    Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+    Properties: 
+      CloudFrontOriginAccessIdentityConfig: 
+        Comment: Origin Access Identity for S3. 
   CloudfrontDistribution:
     Type: AWS::CloudFront::Distribution
     Properties:
@@ -59,8 +62,10 @@ Resources:
         Enabled: true
         Origins:
           - DomainName: !GetAtt [S3WebAppBucket, DomainName]
-            CustomOriginConfig: 
-              OriginProtocolPolicy: match-viewer
+            S3OriginConfig : 
+              OriginAccessIdentity: !Sub
+                - origin-access-identity/cloudfront/${originAccessParam}
+                - originAccessParam: !Ref S3OriginAccessID
             Id: WebAppCloudfrontDistribution
   AlexaSkillFunction:
     Type: AWS::Lambda::Function


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Cloudformation template changes. S3 bucket for assets became private.
Cloudfront was adjusted to account for the private S3 bucket. 
This is the merge from Prod branch, ignoring deployment specific profiles. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
